### PR TITLE
Backport support for SameSite=None cookie flag

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -319,6 +319,8 @@ module Rack
             '; SameSite=Lax'.freeze
           when true, :strict, 'Strict', :Strict
             '; SameSite=Strict'.freeze
+          when :none, 'None', :None
+            '; SameSite=None'.freeze
           else
             raise ArgumentError, "Invalid SameSite value: #{value[:same_site].inspect}"
           end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -97,6 +97,25 @@ describe Rack::Response do
     response["Set-Cookie"].should.equal "foo=bar"
   end
 
+  it "can set SameSite cookies with symbol value :none" do
+    puts 'HIIIIII'
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: :none }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with symbol value :None" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: :None }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with string value 'None'" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: "None" }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
   it "can set SameSite cookies with symbol value :lax" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :lax}

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -98,7 +98,6 @@ describe Rack::Response do
   end
 
   it "can set SameSite cookies with symbol value :none" do
-    puts 'HIIIIII'
     response = Rack::Response.new
     response.set_cookie "foo", { value: "bar", same_site: :none }
     response["Set-Cookie"].must_equal "foo=bar; SameSite=None"


### PR DESCRIPTION
Copy of https://github.com/rack/rack/pull/1455

See https://web.dev/samesite-cookies-explained/ for more details

Spent hours trying to debug the rack tests with only incremental success.  I'm going to try this directly in my nbuild developer environment once this PR is merged into our 3dna `1-6-stable` branch.